### PR TITLE
Quick Download by Coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/.gitignore
+++ b/.gitignore
@@ -220,7 +220,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ streetview-dl --batch streetview_urls_34.05_-118.25.txt --output-dir ./panoramas
 streetview-dl query --lat 34.05 --lng -118.25 --json
 ```
 
+### Quick Download by Coordinates
+
+Download the nearest panorama to a specific spot without needing a URL. Use this when you already have a target coordinate and just want the image.
+
+```bash
+# Simplest usage (lat,lng)
+streetview-dl --quick 42.5052692,-94.1860801
+
+# Shortcut using -q
+streetview-dl -q 42.5052692,-94.1860801 --quality high --output my_spot.jpg
+
+# Using separate flags (useful for scripts)
+streetview-dl --lat 42.5052692 --lng -94.1860801
+```
+
 **Real example - Alcatraz Island (27 acres):**
 ```bash
 # Comprehensive discovery with deep traversal
@@ -302,9 +317,11 @@ streetview-dl --metadata-only "https://maps.url..."
 streetview-dl --metadata "https://maps.url..."
 ```
 
-### Query by coordinates
+### Discovery and Grid Query
 
-The `query` command discovers Street View panoramas at any location using lat/lng coordinates. This enables grid-based sampling, automation, and discovery without requiring URLs.
+The `query` command is used for **discovery and exploration**. It finds Street View panoramas at any location, allowing for grid-based sampling, automation, and browsing availability without requiring URLs.
+
+If you just want the **single closest panorama** to a point, use the `--quick` flag on the main command instead.
 
 ```bash
 # Find nearest panorama (auto-generates URL file)

--- a/streetview_dl/cli.py
+++ b/streetview_dl/cli.py
@@ -174,6 +174,10 @@ def determine_concurrency(quality: str, requested: int) -> int:
 @click.option(
     "--backoff", type=float, default=0.5, help="Retry backoff factor (seconds)"
 )
+@click.option("--lat", type=float, help="Latitude (use with --lng for coordinate download)")
+@click.option("--lng", type=float, help="Longitude (use with --lat for coordinate download)")
+@click.option("--quick", "-q", help="Quick download by coordinates 'lat,lng' (e.g. 42.5,-94.1)")
+@click.option("--radius", type=int, default=50, help="Search radius in meters (default: 50)")
 @click.option(
     "--configure", is_flag=True, help="Configure API key interactively"
 )
@@ -226,6 +230,10 @@ def main(
     verbose: bool,
     accent_color: str,
     concurrency: int,
+    lat: Optional[float] = None,
+    lng: Optional[float] = None,
+    quick: Optional[str] = None,
+    radius: int = 50,
 ) -> None:
     """Download high-resolution Google Street View panoramas."""
 
@@ -270,15 +278,32 @@ def main(
         )
         return
 
-    # Single URL processing
-    if not url:
-        click.echo("Error: URL required (or use --batch for multiple URLs)")
-        click.echo("Try 'streetview-dl --help' for more information.")
+    # Handle --quick option (parses lat,lng string)
+    if quick:
+        try:
+            if "," not in quick:
+                raise click.ClickException("Invalid --quick format. Use 'lat,lng' (e.g., --quick 42.5,-94.1)")
+            q_lat, q_lng = map(str.strip, quick.split(","))
+            lat = float(q_lat)
+            lng = float(q_lng)
+        except ValueError:
+            raise click.ClickException("Invalid coordinates in --quick. Must be numeric 'lat,lng'")
+
+    # Single URL or coordinate processing
+    if not url and (lat is None or lng is None):
+        click.echo("Error: URL required (or use --quick 'lat,lng', or --batch for multiple URLs)")
+        click.echo("\nTo DISCOVER multiple panoramas in an area, use the 'query' command:")
+        click.echo("  streetview-dl query --lat 42.5 --lng -94.1")
+        click.echo("\nTo QUICKLY download the nearest panorama, use --quick:")
+        click.echo("  streetview-dl --quick 42.5,-94.1")
         sys.exit(1)
 
     try:
-        process_single_url(
+        process_location(
             url=url,
+            lat=lat,
+            lng=lng,
+            radius=radius,
             api_key=api_key,
             output=output,
             quality=quality,
@@ -319,8 +344,11 @@ def main(
         sys.exit(1)
 
 
-def process_single_url(
-    url: str,
+def process_location(
+    url: Optional[str],
+    lat: Optional[float],
+    lng: Optional[float],
+    radius: int,
     api_key: Optional[str],
     output: Optional[str],
     quality: str,
@@ -349,17 +377,30 @@ def process_single_url(
     accent_color: str,
     concurrency: int,
 ) -> None:
-    """Process a single URL."""
+    """Process a panorama by URL or coordinates."""
     accent = resolve_accent(accent_color)
     start_time = time.perf_counter()
 
     # Handle --no-crop flag
     if no_crop:
         crop_bottom = 1.0
-
-    # Validate URL
-    if not validate_maps_url(url):
-        raise click.ClickException("Invalid Google Maps Street View URL")
+    
+    # Extract panorama info
+    if url:
+        # Validate URL
+        if not validate_maps_url(url):
+            raise click.ClickException("Invalid Google Maps Street View URL")
+        pano_id, yaw, pitch, url_fov, mode_token, url_date = extract_from_maps_url(url)
+        if not pano_id:
+            raise click.ClickException("Could not extract panorama ID from URL")
+    else:
+        # Coordinates will be used in get_metadata below
+        pano_id = None
+        yaw = None
+        pitch = None
+        url_fov = None
+        mode_token = None
+        url_date = None
 
     # Get API key
     try:
@@ -374,11 +415,20 @@ def process_single_url(
         api_key=api_key, timeout=timeout, retries=retries, backoff=backoff
     )
 
-    # Extract panorama info
-    pano_id, yaw, pitch, url_fov, mode_token, url_date = extract_from_maps_url(url)
-    if not pano_id:
-        raise click.ClickException("Could not extract panorama ID from URL")
-    
+    # Get metadata
+    with console.status(f"[bold {accent}]Fetching metadata..."):
+        if pano_id:
+            street_view_metadata = downloader.get_metadata(pano_id=pano_id)
+        else:
+            street_view_metadata = downloader.get_metadata(lat=lat, lng=lng, radius=radius)
+            pano_id = street_view_metadata.pano_id
+            
+        street_view_metadata.url_yaw = yaw
+        street_view_metadata.url_pitch = pitch
+        street_view_metadata.url_fov = url_fov  # Use URL-extracted FOV, not CLI FOV
+        street_view_metadata.url_mode_token = mode_token
+        street_view_metadata.url_date = url_date
+
     # Validate option combinations
     if clip in ("left", "right") and fov and fov < 180:
         console.print(
@@ -392,17 +442,6 @@ def process_single_url(
             console.print(f"[dim]Yaw: {yaw:.2f}°[/dim]")
         if pitch is not None:
             console.print(f"[dim]Pitch: {pitch:.2f}°[/dim]")
-
-    # Get metadata
-    with console.status(f"[bold {accent}]Fetching metadata..."):
-        street_view_metadata = downloader.get_metadata(pano_id=pano_id)
-        street_view_metadata.url_yaw = yaw
-        street_view_metadata.url_pitch = pitch
-        street_view_metadata.url_fov = url_fov  # Use URL-extracted FOV, not CLI FOV
-        street_view_metadata.url_mode_token = mode_token
-        street_view_metadata.url_date = url_date
-
-    if verbose:
         console.print(
             f"[dim]Resolution: {street_view_metadata.image_width}×{street_view_metadata.image_height}[/dim]"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,3 +158,37 @@ def test_query_command_no_results(mock_downloader_class, mock_validate, mock_get
     
     assert result.exit_code == 1
     assert "No panoramas found" in result.output or "Query failed" in result.output
+
+
+@patch('streetview_dl.cli.get_api_key')
+@patch('streetview_dl.cli.validate_api_key')
+@patch('streetview_dl.cli.process_location')
+def test_cli_quick_option(mock_process, mock_validate, mock_get_key):
+    """Test that the --quick option correctly triggers coordinate-based download."""
+    mock_get_key.return_value = "test_api_key"
+    mock_validate.return_value = True
+    
+    runner = CliRunner()
+    result = runner.invoke(main, ["--quick", "34.05,-118.25"])
+    
+    assert result.exit_code == 0
+    # Verify process_location was called with the correct lat/lng
+    mock_process.assert_called_once()
+    kwargs = mock_process.call_args.kwargs
+    assert kwargs["lat"] == 34.05
+    assert kwargs["lng"] == -118.25
+    assert kwargs["url"] is None
+
+
+@patch('streetview_dl.cli.get_api_key')
+@patch('streetview_dl.cli.validate_api_key')
+def test_cli_quick_option_invalid_format(mock_validate, mock_get_key):
+    """Test that --quick with invalid format shows an error."""
+    mock_get_key.return_value = "test_api_key"
+    mock_validate.return_value = True
+    
+    runner = CliRunner()
+    result = runner.invoke(main, ["--quick", "34.05"])  # Missing comma
+    
+    assert result.exit_code != 0
+    assert "Invalid --quick format" in result.output


### PR DESCRIPTION
## Summary
This PR introduces a streamlined way to download Street View panoramas using coordinates directly, without requiring a Google Maps URL. It adds a new `--quick` (`-q`) flag and individual `--lat`/`--lng` options to the main download command.

## Rationale
Previously, downloading by coordinates was a two-step process:
1. Use `streetview-dl query` to discover panoramas and generate a URL file.
2. Use `streetview-dl --batch` to download from that file.

While the `query` command is excellent for discovery and exploration, some users might just want the closest panorama to a specific point. This PR provides a "fast path" for that use case.

## Key Features
- **`--quick` / `-q` option**: Accepts a `"lat,lng"` string (e.g., `-q 42.5,-94.1`).
- **`--lat` / `--lng` options**: Separate flags for easier programmatic use in scripts.
- **Auto-Discovery**: Automatically fetches metadata for the nearest panorama within a search radius (default 50m) and proceeds to download it at the requested quality.
- **Unified Logic**: The `process_location` function now handles both URL-based and coordinate-based inputs, ensuring all filters, cropping, and quality settings work identically for both modes.

## Changes
- **`streetview_dl/cli.py`**:
    - Added new options to the `main` command.
    - Refactored `process_single_url` into `process_location` to handle coordinates.
    - Updated help text to distinguish between "Quick Download" and "Discovery (Query)".
- **`README.md`**:
    - Added a "Quick Download by Coordinates" section to the Quick Start guide.
    - Clarified the use cases for `query` vs. `--quick`.
- **`tests/test_cli.py`**:
    - Added `test_cli_quick_option` to verify correct argument parsing and logic branching.
    - Added `test_cli_quick_option_invalid_format` to verify error handling for malformed coordinate strings.

## Usage Examples
```bash
# Quick download using the new shortcut
streetview-dl --quick 42.5052692,-94.1860801 --quality high

# Using separate flags
streetview-dl --lat 42.5052692 --lng -94.1860801 --output my_spot.jpg
```

## Related Subcommand
The `query` command remains the primary tool for:
- Discovering multiple panoramas in an area.
- Viewing capture dates and distances before downloading.
- Generating batch URL lists for large-scale sampling.
