### PR TITLE
Adding support for non-Google Street View panoramas

### DIFF
--- a/streetview_dl/cli.py
+++ b/streetview_dl/cli.py
@@ -410,7 +410,11 @@ def process_single_url(
             console.print(f"[dim]Date: {street_view_metadata.date}[/dim]")
         if url_date:
             console.print(f"[dim]URL Date: {url_date}[/dim]")
-
+    
+    if street_view_metadata.image_width <= 8192 and quality == "high":
+        console.print("High quality not available for this pano, switching to medium")
+        quality = "medium"
+    
     # Handle historical discovery mode
     if historical or historical_download:
         if not street_view_metadata.lat or not street_view_metadata.lng:

--- a/streetview_dl/core.py
+++ b/streetview_dl/core.py
@@ -297,7 +297,11 @@ class StreetViewDownloader:
         session = self.create_session()
 
         # Calculate tile grid dimensions
-        scale_factor = 2 ** (5 - z)  # Scale down from max resolution
+        if metadata.image_width <= 8192:
+            scale_factor = 2 ** (4 - z)  # Scale down from max resolution, level 4 is max for smaller panos
+        else:
+            scale_factor = 2 ** (5 - z)  # Scale down from max resolution
+
         scaled_width = metadata.image_width // scale_factor
         scaled_height = metadata.image_height // scale_factor
 

--- a/streetview_dl/metadata.py
+++ b/streetview_dl/metadata.py
@@ -3,7 +3,7 @@
 import re
 import urllib.parse as urlparse
 from typing import Any, Dict, Optional, Tuple
-
+import base64
 from pydantic import BaseModel, Field
 
 
@@ -175,9 +175,9 @@ def extract_from_maps_url(
         return pano_id, yaw, pitch, fov, mode_token, date
 
     # Fallback: try to extract panorama ID from the !1s token pattern
-    pano_match = re.search(r"!3m5!1s([^!]+)", haystack)
+    pano_match = re.search(r"!1s([^!]+)", haystack)
     if pano_match:
-        return pano_match.group(1), yaw_from_path, pitch_from_path, fov, mode_token, date
+        return check_panoid(pano_match.group(1)), yaw_from_path, pitch_from_path, fov, mode_token, date
 
     # Last resort: try direct panoid parameter
     pano_match = re.search(r"[?&]panoid=([^&]+)", haystack)
@@ -209,3 +209,15 @@ def validate_maps_url(url: str) -> bool:
         "panoid=",  # direct pano id parameter
     ]
     return any(indicator in url for indicator in street_view_indicators)
+
+def check_panoid(data: str):
+    """Check if pano ID needs to be converted to base64, as is required for many/all non-Google panos"""
+    if data.startswith("CIH"):      # Needs to be converted if the ID starts with CI or perhaps CIHM
+        print("Converting pano ID to base64 format")
+        return convert_panoid(data)
+    return data                     # Do not modify if no conversion is required
+
+def convert_panoid(data: str) -> str:
+    """Convert pano ID to base64 format"""
+    payload = f"\x08\n\x12{chr(len(data))}{data}".encode("utf-8")    # Preamble includes length of pano ID to follow
+    return base64.b64encode(payload).decode("utf-8").replace("=", ".")

--- a/streetview_dl/metadata.py
+++ b/streetview_dl/metadata.py
@@ -210,9 +210,9 @@ def validate_maps_url(url: str) -> bool:
     ]
     return any(indicator in url for indicator in street_view_indicators)
 
-def check_panoid(data: str):
+def check_panoid(data: str) -> str:
     """Check if pano ID needs to be converted to base64, as is required for many/all non-Google panos"""
-    if data.startswith("CIH"):      # Needs to be converted if the ID starts with CI or perhaps CIHM
+    if data.startswith("CIH"):      # Needs to be converted if the ID starts with CIHM (based on spot checks, may need a better method in the future)
         print("Converting pano ID to base64 format")
         return convert_panoid(data)
     return data                     # Do not modify if no conversion is required

--- a/streetview_dl/metadata.py
+++ b/streetview_dl/metadata.py
@@ -212,12 +212,13 @@ def validate_maps_url(url: str) -> bool:
 
 def check_panoid(data: str) -> str:
     """Check if pano ID needs to be converted to base64, as is required for many/all non-Google panos"""
-    if data.startswith("CIH"):      # Needs to be converted if the ID starts with CIHM (based on spot checks, may need a better method in the future)
+    # Needs to be converted if the ID starts with these prefixes (no definitive list, may need to expand in the future)
+    if data.startswith(("CIHM", "AF1Q", "CIAB")): 
         print("Converting pano ID to base64 format")
         return convert_panoid(data)
-    return data                     # Do not modify if no conversion is required
+    return data  # Do not modify if no conversion is required
 
 def convert_panoid(data: str) -> str:
     """Convert pano ID to base64 format"""
-    payload = f"\x08\n\x12{chr(len(data))}{data}".encode("utf-8")    # Preamble includes length of pano ID to follow
+    payload = f"\x08\n\x12{chr(len(data))}{data}".encode("utf-8")  # Preamble includes length of pano ID to follow
     return base64.b64encode(payload).decode("utf-8").replace("=", ".")


### PR DESCRIPTION
## Summary
This adds support for non-Google Street View panoramas, and includes proper support for handling lower resolution panoramas.

## Changes
- **`cli.py`**:
  - Added a check on image size.  If high quality is not available (max width less than or equal to 8192), downgrade to medium automatically and print a console message indicating this change was made.  Otherwise, a blank image is created.  Continuing with a message feels more appropriate than stopping, especially if batch processing.
- **`core.py`**:
  - Added scale factor adjustment based on max resolution, as smaller panoramas will be cropped incorrectly otherwise.  These panoramas don't have zoom 5 (high quality) available and this causes issues with scaling.
- **`metadata.py`**:
  - Search for only "!1s" instead of a longer string in URL to extract more panorama IDs, including those from non-Google panoramas.  The longer string of "!3m5!1s" seems to miss non-Google panoramas (and perhaps others).
  - Added a check and conversion process to the format for non-Google panoramas.  These must have a preamble added and converted to base64 to be passed to the API.

## Notes
- Some of this was accomplished via reverse engineering, so testing on a wider range of non-Google panoramas may be required.
- The list of characters to identify non-Google panoramas may not be complete.
- This resolves closed issue #4, though some of the example URLs there do not work.  The URLs may be malformed, as in a browser the image is shown but with an error.